### PR TITLE
Respect Obsidian's Excluded files setting when building the graph

### DIFF
--- a/src/adapter.ts
+++ b/src/adapter.ts
@@ -97,11 +97,28 @@ export function buildGraphFromFiles(notes: NoteInput[], settings: BrainAtlasSett
 }
 
 export function buildGraph(app: App, settings: BrainAtlasSettings): BrainGraph {
-  const notes = app.vault.getMarkdownFiles().map((file) => ({
-    file: toFileLike(file),
-    cache: toCacheLike(app.metadataCache.getFileCache(file))
-  }));
+  const notes = app.vault
+    .getMarkdownFiles()
+    .filter((file) => !isUserIgnored(app, file.path))
+    .map((file) => ({
+      file: toFileLike(file),
+      cache: toCacheLike(app.metadataCache.getFileCache(file))
+    }));
   return buildGraphFromFiles(notes, settings);
+}
+
+/**
+ * Obsidian never filters `Vault.getMarkdownFiles()` by the user's "Excluded files"
+ * setting (Settings > Files & Links) - that list only hides files from the UI (file
+ * explorer, quick switcher, search, core graph, etc). Plugins that walk the vault
+ * themselves have to re-check each path against it, via the internal (undocumented)
+ * `MetadataCache.isUserIgnored`, or ignored folders leak back into the atlas.
+ */
+export function isUserIgnored(app: App, path: string): boolean {
+  const metadataCache = app.metadataCache as App["metadataCache"] & {
+    isUserIgnored?: (path: string) => boolean;
+  };
+  return metadataCache.isUserIgnored?.(path) ?? false;
 }
 
 function toFileLike(file: TFile): FileLike {

--- a/src/diagnostics.ts
+++ b/src/diagnostics.ts
@@ -1,6 +1,6 @@
 import type { App, CachedMetadata } from "obsidian";
 import { classifyNoteDetailed, normalizeKind, resolveLobeOverride } from "./classify.ts";
-import type { NoteInput } from "./adapter.ts";
+import { isUserIgnored, type NoteInput } from "./adapter.ts";
 import { KIND_TO_LOBE } from "./shape.ts";
 import {
   frontmatterValueKeys,
@@ -29,10 +29,13 @@ export interface ClassificationReport {
 }
 
 export function buildClassificationReport(app: App, settings: BrainAtlasSettings): ClassificationReport {
-  const notes = app.vault.getMarkdownFiles().map((file) => ({
-    file: { path: file.path, basename: file.basename },
-    cache: toCacheLike(app.metadataCache.getFileCache(file))
-  }));
+  const notes = app.vault
+    .getMarkdownFiles()
+    .filter((file) => !isUserIgnored(app, file.path))
+    .map((file) => ({
+      file: { path: file.path, basename: file.basename },
+      cache: toCacheLike(app.metadataCache.getFileCache(file))
+    }));
   return buildClassificationReportFromFiles(notes, settings);
 }
 

--- a/test/adapter.test.mjs
+++ b/test/adapter.test.mjs
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildGraphFromFiles } from "../src/adapter.ts";
+import { buildGraph, buildGraphFromFiles, isUserIgnored } from "../src/adapter.ts";
 import { DEFAULT_SETTINGS } from "../src/settings.ts";
 
 function note(path, cache = {}) {
@@ -145,4 +145,33 @@ test("buildGraphFromFiles limits hubs to the configured top percentage when degr
   const graph = buildGraphFromFiles(notes, { ...DEFAULT_SETTINGS, hubThresholdPercent: 10 });
 
   assert.equal(graph.nodes.filter((node) => node.hub).length, 2);
+});
+
+function fakeApp(files, ignoredPaths = []) {
+  const ignored = new Set(ignoredPaths);
+  return {
+    vault: {
+      getMarkdownFiles: () => files
+    },
+    metadataCache: {
+      getFileCache: () => ({}),
+      isUserIgnored: (path) => ignored.has(path)
+    }
+  };
+}
+
+test("buildGraph drops notes that live under Obsidian's Excluded files patterns", () => {
+  const files = [
+    { path: "Projects/Keep.md", basename: "Keep" },
+    { path: "Archive/Skip.md", basename: "Skip" }
+  ];
+  const app = fakeApp(files, ["Archive/Skip.md"]);
+
+  const graph = buildGraph(app, DEFAULT_SETTINGS);
+
+  assert.deepEqual(graph.nodes.map((node) => node.id), ["Projects/Keep.md"]);
+});
+
+test("isUserIgnored treats a missing internal API as not-ignored", () => {
+  assert.equal(isUserIgnored({ metadataCache: {} }, "Anything.md"), false);
 });


### PR DESCRIPTION
## Summary
- `buildGraph()` (src/adapter.ts) and `buildClassificationReport()` (src/diagnostics.ts) both call `app.vault.getMarkdownFiles()` directly, which is **not** filtered by Obsidian's Settings → Files & Links → Excluded files patterns (`userIgnoreFilters`) — that filtering only applies to Obsidian's own UI surfaces (file explorer, search, core graph, quick switcher, etc).
- As a result, notes under a folder the user excluded still showed up as nodes in the 3D graph and were still counted in the classification report.
- Added an `isUserIgnored(app, path)` helper that safely calls the internal (undocumented but stable, used throughout Obsidian's own core) `MetadataCache.isUserIgnored`, and filtered both entry points with it.

## Test plan
- [x] `npx tsc -noEmit -skipLibCheck` passes
- [x] `npm run lint` passes
- [x] `npm test` passes (125/125, including 2 new tests covering the filter and the fallback when the internal API is unavailable)
- [x] `npm run build` succeeds
- [x] Manually verified via `npm run install-local` against a real vault with an excluded folder: notes under the excluded folder no longer appear in the graph