### PR TITLE
fix: spawn signal pulses in the WebGL2 renderer (fixes #8)

### DIFF
--- a/src/gl/brain-gl-renderer.ts
+++ b/src/gl/brain-gl-renderer.ts
@@ -513,6 +513,16 @@ export class BrainGLRenderer extends RenderCore {
       this.overlayCtx.clearRect(0, 0, this.width, this.height);
     }
 
+    const interLobeEdges = graph.edges.filter((edge) => {
+      const a = graph.idx[edge.a];
+      const b = graph.idx[edge.b];
+      return a && b && a._lobeName !== b._lobeName;
+    });
+
+    // Signal spawning is state mutation (shared across passes), not a draw pass;
+    // keep it unconditional so the "signals" pass stays deterministic when gated.
+    this.spawnSignals(now, graph, interLobeEdges);
+
     // ---- Pass: background (radial gradient, opaque full-screen quad) ----
     if (this.passEnabled("background")) {
       this.drawBackground(gl, graph, proj.cx, proj.cy);

--- a/test/renderer-signals.test.mjs
+++ b/test/renderer-signals.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+
+const RENDERERS = [
+  ["Canvas2D", "../src/renderer.ts"],
+  ["WebGL2", "../src/gl/brain-gl-renderer.ts"]
+];
+
+// spawnSignals() and drawSignals() are a pair: the spawner is the only thing that
+// ever pushes into the shared this.signals list, so a renderer that draws signals
+// without spawning them animates nothing at all. The WebGL2 renderer shipped that
+// way in 0.2.1 and the A/B harness could not catch it — it injects a fixed signal
+// list via setSignalsForTest to stay deterministic, which bypasses spawnSignals.
+for (const [name, path] of RENDERERS) {
+  test(`${name} renderer spawns signals as well as drawing them`, () => {
+    const source = readFileSync(new URL(path, import.meta.url), "utf8");
+    assert.match(source, /this\.drawSignals\(/);
+    assert.match(
+      source,
+      /this\.spawnSignals\(/,
+      `${name} draws signals but never calls spawnSignals(), so this.signals stays empty and no pulse ever renders`
+    );
+  });
+}


### PR DESCRIPTION
Fixes #8.

## Summary

`spawnSignals()` is the only thing that ever pushes into the shared `this.signals` list, and it was called from the Canvas2D `drawScene()` alone. The WebGL2 `drawScene()` called `drawSignals()` against a list that stayed permanently empty, so the signal-pulse animation never ran under WebGL2 — the default renderer on desktop since 0.2.1.

The fix computes the cross-lobe edge subset and calls `spawnSignals()` before the passes, mirroring `src/renderer.ts` exactly (unconditional, so the `signals` pass stays deterministic when gated). @agentkodiak-code's root-cause analysis on the issue was correct in every detail.

## Why the A/B harness didn't catch it

The pixel-diff harness injects a fixed signal list via `setSignalsForTest` to stay deterministic, which bypasses `spawnSignals()` entirely — both renderers were handed identical particles, so they matched pixel-for-pixel while the real WebGL2 path spawned nothing. That's a blind spot in an otherwise strong suite, so this adds `test/renderer-signals.test.mjs`: any renderer that calls `drawSignals()` must also call `spawnSignals()`.

## Verification

- `npm run lint` clean, `npm test` 127/127, `npm run build` succeeds
- `npm run test:ab` — 75 passed, 1 skipped (headed-only). The change is pixel-neutral: in deterministic mode `spawnSignals()` only prunes expired particles, and Canvas2D already did that, so both renderers stay identical.
- Behavioural before/after, driving a live `BrainGLRenderer` through the harness with `setDeterministic(false)` and 12 frames of 1s scene time (fixture graph: 134 nodes, 267 edges, 90 cross-lobe):

  | | live signal particles per frame |
  |---|---|
  | before | `0,0,0,0,0,0,0,0,0,0,0,0` |
  | after | `1,2,3,3,4,3,3,4,3,4,3,4` |

  The steady 3-4 matches the design: one spawn per 900ms against a 2.4-3.5s particle lifetime.

## Note

`playwright.config.mjs` sets `testDir: __dirname` (repo root) with `testMatch: ["test/ab/*.test.mjs"]`. If you have a git worktree checked out under the repo, the glob descends into it, finds its `node_modules/playwright`, and `npm run test:ab` dies with a "two instances of Playwright Test" error. Scoping `testDir` to `test/ab` fixes it. Left out of this PR to keep it focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)