### PR TITLE
fix: drag the near surface of the brain, not the far one (fixes #1)

### DIFF
--- a/src/render-core.ts
+++ b/src/render-core.ts
@@ -50,6 +50,35 @@ export interface NodeDragState {
 
 export type DragState = RotateDragState | NodeDragState;
 
+/** Pointer travel, in CSS pixels, that maps to one radian of rotation. */
+export const DRAG_PIXELS_PER_RADIAN = 180;
+
+/** Vertical rotation limit, keeping the volume from tumbling past its poles. */
+export const MAX_ROT_X = 1.4;
+
+/**
+ * Map a canvas drag onto camera rotation.
+ *
+ * Both deltas are subtracted, not added. The projector's +z runs away from the
+ * camera, so adding them rotates the volume as though the pointer had grabbed
+ * its FAR surface: the near side then travels against the cursor and the brain
+ * reads as inside-out, with no way to tell which nodes are closest. Subtracting
+ * puts the near surface under the cursor, matching node dragging (which already
+ * follows the pointer) and every other orbit control.
+ */
+export function rotationFromDrag(
+  start: { x: number; y: number },
+  screenDx: number,
+  screenDy: number
+): { x: number; y: number } {
+  const dx = screenDx / DRAG_PIXELS_PER_RADIAN;
+  const dy = screenDy / DRAG_PIXELS_PER_RADIAN;
+  return {
+    x: Math.max(-MAX_ROT_X, Math.min(MAX_ROT_X, start.x - dy)),
+    y: start.y - dx
+  };
+}
+
 export interface BrainRendererOptions {
   idleAutoRotate: boolean;
   showLobeLabels: boolean;
@@ -420,10 +449,9 @@ export abstract class RenderCore {
         this.hoverId = this.drag.nodeId;
         this.options.onChange?.();
       } else {
-        const dx = screenDx / 180;
-        const dy = screenDy / 180;
-        this.rot.y = this.drag.rotY + dx;
-        this.rot.x = Math.max(-1.4, Math.min(1.4, this.drag.rotX + dy));
+        const next = rotationFromDrag({ x: this.drag.rotX, y: this.drag.rotY }, screenDx, screenDy);
+        this.rot.x = next.x;
+        this.rot.y = next.y;
       }
       this.lastUserAt = performance.now();
       this.requestImmediateFrame();

--- a/test/renderer-drag.test.mjs
+++ b/test/renderer-drag.test.mjs
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { rotationFromDrag, MAX_ROT_X } from "../src/render-core.ts";
+import { Brain3D } from "../src/shape.ts";
+
+const BASE = { scale: 300, cx: 400, cy: 300, dist: 3.4 };
+const project = (rot) => Brain3D.makeProjector({ ...BASE, rotX: rot.x, rotY: rot.y });
+
+// The projector's +z runs AWAY from the camera (f = scale / (dist + z) shrinks as
+// z grows), so the surface nearest the viewer sits at negative z.
+const FRONT = { x: 0, y: 0, z: -1 };
+const BACK = { x: 0, y: 0, z: 1 };
+const REST = { x: 0, y: 0 };
+
+test("dragging right carries the near surface right, not the far one", () => {
+  const rot = rotationFromDrag(REST, 90, 0);
+  const before = project(REST);
+  const after = project(rot);
+
+  assert.ok(
+    after(FRONT).sx > before(FRONT).sx,
+    "the near surface must follow the cursor — moving it the other way is what makes the volume read as inside-out (#1)"
+  );
+  assert.ok(after(BACK).sx < before(BACK).sx, "the far surface travels opposite the cursor");
+});
+
+test("dragging down carries the near surface down", () => {
+  const rot = rotationFromDrag(REST, 0, 90);
+  const before = project(REST);
+  const after = project(rot);
+
+  assert.ok(after(FRONT).sy > before(FRONT).sy, "the near surface must follow the cursor vertically too");
+});
+
+test("dragging back to the start restores the original rotation", () => {
+  const out = rotationFromDrag(REST, 120, -60);
+  const back = rotationFromDrag(out, -120, 60);
+
+  assert.ok(Math.abs(back.x - REST.x) < 1e-12);
+  assert.ok(Math.abs(back.y - REST.y) < 1e-12);
+});
+
+test("vertical rotation stays clamped so the volume cannot tumble past vertical", () => {
+  assert.equal(rotationFromDrag(REST, 0, 100_000).x, -MAX_ROT_X);
+  assert.equal(rotationFromDrag(REST, 0, -100_000).x, MAX_ROT_X);
+});
+
+test("horizontal rotation is unclamped so the volume spins freely", () => {
+  const spun = rotationFromDrag(REST, 100_000, 0);
+  assert.ok(Math.abs(spun.y) > Math.PI * 2);
+});


### PR DESCRIPTION
Fixes #1.

## The bug

@CeaselessWatcher described dragging as happening "on the back-side of the 3D space, rather than the front," producing a warping effect with no cue for which nodes are nearest the camera. That's exactly what was happening, and it's measurable rather than a matter of taste.

`onPointerMove` **added** the pointer delta to `rot.x` / `rot.y`. The projector's `+z` runs away from the camera (`f = scale / (dist + z)` shrinks as `z` grows), so adding rotates the volume as though the pointer had grabbed its far surface. Measured against the real projector at rest, a 90px drag to the right:

| surface | screen x before | after |
|---|---|---|
| near pole (`z = -1`) | 400.0 | **206.1** |
| far pole (`z = +1`) | 400.0 | **514.3** |

The far surface was the one following the cursor. Same inversion vertically.

## The fix

Subtract both deltas instead. This also settles an internal disagreement: node dragging already tracks the pointer correctly via its `right`/`up` basis vectors, so the two drag modes in the same canvas were behaving differently.

I went with a straight correction rather than the toggle option the issue offered as an alternative. A setting to choose between "correct" and "inside-out" is clutter, and the app's own node dragging already establishes which way is right. Trivially revertible if you'd rather ship the toggle.

## Testing

The mapping is extracted as a pure `rotationFromDrag()` so it can be tested against the real projector instead of through synthesized DOM pointer events. `test/renderer-drag.test.mjs` asserts the near surface follows the cursor on both axes, that drag-and-return restores the original rotation, and that the vertical clamp still holds.

Confirmed the tests fail against the old signs — 3 of 5 fail when the deltas are added back.

- `npm test` 132/132, `npm run lint` clean, `npm run build` succeeds
- `npm run test:ab` 75 passed / 1 skipped (headed-only) — rotation drag isn't exercised by the pixel-diff suite, but no regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)